### PR TITLE
chore: migrate to validata v0.12.0

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,3 +3,6 @@ VUE_APP_DATAGOUV_PUBLISH_URL=https://demo.data.gouv.fr
 VUE_APP_DATAGOUV_TABULAR_API=https://tabular-api.data.gouv.fr
 VUE_APP_GRIST_URL=http://localhost:8484
 VUE_APP_GRIST_CHEAT_URL=http://mongrist.dev
+
+# Validata POST validation endpoint URL
+VUE_APP_VALIDATA_URL=https://preprod-api-validata.dataeng.etalab.studio/validate

--- a/src/components/validata/formatting.ts
+++ b/src/components/validata/formatting.ts
@@ -1,9 +1,9 @@
 import type { IGrist } from "./spi";
-import type { ValidationReport } from "./types/report";
+import type { ValidationResponse } from "./types/report";
 import type { TableData } from "./types/records";
 
 export async function highlightErrors(
-  report: ValidationReport,
+  report: ValidationResponse,
   table: TableData,
   gristService: IGrist
 ) {
@@ -52,10 +52,10 @@ function findStrIdFromLabel(
  * Returns for each column an array of row numbers containing invalid values
  */
 function aggregateErrorRowsByLabel(
-  report: ValidationReport
+  report: ValidationResponse
 ): Record<string, number[]> {
   const errorRowsByLabel: Record<string, number[]> = {};
-  const reportedCellErrors = report?.report?.tasks[0]?.errors || [];
+  const reportedCellErrors = report?.report?.errors || [];
 
   for (const err of reportedCellErrors) {
     if (err.fieldName && err.rowNumber) {

--- a/src/components/validata/infra/validata.ts
+++ b/src/components/validata/infra/validata.ts
@@ -1,8 +1,13 @@
 import { IValidata } from "../spi";
-import { ValidationReport } from "../types/report";
+import { ValidationResponse } from "../types/report";
 
 interface Options {
   header_case?: boolean;
+}
+
+const VALIDATA_URL = process.env.VUE_APP_VALIDATA_URL;
+if (!VALIDATA_URL) {
+  throw new Error("Please define VUE_APP_VALIDATA_URL environment variable");
 }
 
 export class ValidataService implements IValidata {
@@ -10,10 +15,10 @@ export class ValidataService implements IValidata {
     csvTable: string,
     schemaURL: string,
     options: Options
-  ): Promise<ValidationReport> {
+  ): Promise<ValidationResponse> {
+    const url = VALIDATA_URL;
     const body = makeRequestBody(csvTable, schemaURL, options);
 
-    const url = "https://api.validata.etalab.studio/validate";
     return fetch(url, {
       method: "POST", // *GET, POST, PUT, DELETE, etc.
       mode: "cors", // no-cors, *cors, same-origin

--- a/src/components/validata/plugin.ts
+++ b/src/components/validata/plugin.ts
@@ -2,7 +2,7 @@ import { highlightErrors } from "./formatting";
 
 import type { IGrist, IValidata } from "./spi";
 import {
-  type ValidationReport,
+  type ValidationResponse,
   type Error,
   type ErrorsByType,
   relatesToRow,
@@ -55,75 +55,57 @@ export async function validateTable(
 /** Returns the last evaluated validation report, if any.
  */
 
-export function getValidationReport(): ValidationReport | undefined {
+export function getValidationReport(): ValidationResponse | undefined {
   const getValidationReport = useValidationReport().getValidationReport;
   return getValidationReport();
 }
 
 /** Stores a validation report for future reference with `getValidationReport`
  */
-function storeValidationReport(report: ValidationReport) {
+function storeValidationReport(report: ValidationResponse) {
   const setValidationReport = useValidationReport().setValidationReport;
   setValidationReport(report);
 }
 
 /** Given a report, updates (displays) all table errors
  */
-export function updateGeneralErrors(report: ValidationReport) {
+export function updateGeneralErrors(report: ValidationResponse) {
   errors.structureErrors = extractStructureErrors(report);
   errors.rowErrors = extractRowErrors(report);
-  errors.warnings = report.report.tasks[0].warnings;
+  errors.warnings = report.report.warnings;
 }
 
 /** Given a report, updates (displays) errors specific to line n
  */
-export function updateRowErrors(report: ValidationReport, rowId: number) {
+export function updateRowErrors(report: ValidationResponse, rowId: number) {
   errors.selectedRowErrors = extractSelectedRowErrors(report, rowId);
 }
 
-function extractStructureErrors(report: ValidationReport): Error[] {
+function extractStructureErrors(report: ValidationResponse): Error[] {
   // "structure" in a loose sense of anything not related to a row, may include "table" errors which can be
   // categorized as "body" errors rather than structure.
-  const errors1 = report.report.errors || [];
-  let errors2: Error[] = [];
-  if (report.report.tasks.length > 0) {
-    errors2 = report.report.tasks[0].errors;
-  }
-
-  const allErrors = errors1.concat(errors2);
-
-  return allErrors.filter((e) => !relatesToRow(e));
+  const errors = report.report.errors || [];
+  return errors.filter((e) => !relatesToRow(e));
 }
 
-function extractRowErrors(report: ValidationReport): Error[] {
+function extractRowErrors(report: ValidationResponse): Error[] {
   // "structure" in a loose sense of anything not related to a row, may include "table" errors which can be
   // categorized as "body" errors rather than structure.
-  const errors1 = report.report.errors || [];
-  let errors2: Error[] = [];
-  if (report.report.tasks.length > 0) {
-    errors2 = report.report.tasks[0].errors;
-  }
-
-  const allErrors = errors1.concat(errors2);
-
-  return allErrors.filter(relatesToRow);
+  const errors = report.report.errors || [];
+  return errors.filter(relatesToRow);
 }
 
 function extractSelectedRowErrors(
-  report: ValidationReport,
+  report: ValidationResponse,
   rowId: number
 ): Error[] {
-  if (report.report.tasks.length == 0) {
-    return [];
-  }
-
-  return report.report.tasks[0].errors
+  return report.report.errors
     .filter(relatesToRow)
     .filter((err) => err.rowId == rowId);
 }
 
-function addRowIds(report: ValidationReport, table: TableData) {
-  for (const error of report.report.tasks[0].errors) {
+function addRowIds(report: ValidationResponse, table: TableData) {
+  for (const error of report.report.errors) {
     if (error.rowNumber) {
       // - 2 because we ignore header row + 0-indexed array whereas rowNumber
       // is 1-indexed

--- a/src/components/validata/types/report.ts
+++ b/src/components/validata/types/report.ts
@@ -1,23 +1,12 @@
-interface Meta {
-  args: {
-    schema: string;
-    url: string;
-  };
-  validataTableVersion: string;
-  validataCoreVersion: string;
-}
-
 export interface Error {
-  code: string;
-  description: string;
-  labels: string[];
+  cell?: unknown;
+  cells?: unknown[];
   message: string;
-  name: string;
-  note: string;
   fieldNumber?: number;
   fieldName?: string;
   rowNumber?: number;
   tags: Tag[];
+  type: string;
 
   // specfific to Grist
   rowId?: number;
@@ -27,25 +16,11 @@ interface Stats {
   errors: number;
 }
 
-interface Task {
-  errors: Error[];
-  partial: boolean;
-  stats: {
-    errors: number;
-  };
-  warnings: string[];
-  time: number;
-  valid: boolean;
-}
-
 interface Report {
-  date: string;
   errors: Error[];
   stats: Stats;
-  tasks: Task[];
-  time: number;
   valid: boolean;
-  version: string;
+  warnings: string[];
 }
 
 export interface ErrorsByType {
@@ -55,8 +30,14 @@ export interface ErrorsByType {
   warnings: string[];
 }
 
-export interface ValidationReport {
-  _meta: Meta;
+export interface ValidationResponse {
+  schema: string;
+  url: string;
+  date: string;
+  options: {
+    ignore_header_case: boolean;
+  };
+  version: string;
   report: Report;
 }
 

--- a/src/components/validata/useValidationReport.ts
+++ b/src/components/validata/useValidationReport.ts
@@ -1,14 +1,14 @@
-import { type ValidationReport } from "./types/report";
+import { type ValidationResponse } from "./types/report";
 import { ref } from "vue";
 
-const validationReport = ref<ValidationReport | undefined>(undefined);
+const validationReport = ref<ValidationResponse | undefined>(undefined);
 
 export function useValidationReport() {
   function getValidationReport() {
     return validationReport.value;
   }
 
-  function setValidationReport(report: ValidationReport) {
+  function setValidationReport(report: ValidationResponse) {
     validationReport.value = report;
   }
 


### PR DESCRIPTION
Validata v0.12.0 introduce a breaking report simplification.

This PR adapts the code to this.

/!\ It introduces a new required environment variable VUE_APP_VALIDATA_URL

For the migration, the preproduction URL is temporarily used. Once the v0.12.0 deployed, the environment variable will need to change to the production URL.