### PR TITLE
chore: move to validata production URL

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,4 +5,4 @@ VUE_APP_GRIST_URL=http://localhost:8484
 VUE_APP_GRIST_CHEAT_URL=http://mongrist.dev
 
 # Validata POST validation endpoint URL
-VUE_APP_VALIDATA_URL=https://preprod-api-validata.dataeng.etalab.studio/validate
+VUE_APP_VALIDATA_URL=https://api.validata.etalab.studio/validate


### PR DESCRIPTION
This PR changes in the example environment file the Validata URL from the preproduction to the production environment. 

The reason why it was the preproduction URL in the first place was to anticipate coming breaking changes. 

/!\ Along this PR, it is required to also change the environment files on the plugin's production environment ! 