### PR TITLE
Allow user to fetch data even without an org

### DIFF
--- a/src/components/datagouv/ImporterForm.vue
+++ b/src/components/datagouv/ImporterForm.vue
@@ -42,13 +42,13 @@
             </div>
         </div>
         <div @click="selectOrganization(null, null)" class="fr-tile fr-tile--sm fr-tile--horizontal fr-enlarge-link" id="tile-6661">
-                <div class="fr-tile__body">
-                    <div class="fr-tile__content">
-                        <h3 class="fr-tile__title">
-                            <a href="#">Récupérer des données sur tout data.gouv.fr</a>
-                        </h3>
-                    </div>
+            <div class="fr-tile__body">
+                <div class="fr-tile__content">
+                    <h3 class="fr-tile__title">
+                        <a href="#">Récupérer des données sur tout data.gouv.fr</a>
+                    </h3>
                 </div>
+            </div>
         </div>
     </div>
 
@@ -206,7 +206,7 @@ export default defineComponent({
       } catch (error) {
         console.error("Error datagouv search", error);
         throw error;
-      }     
+      }
     }
 
     const debouncedSearch = debounce(searchDatagouv, 500);
@@ -280,7 +280,7 @@ export default defineComponent({
             }
         }
         ongoingStep.value = 3
-        
+
 
         for (let i = 0; i <= nbPages.value; i++) {
             let calculus = Math.floor((((((i+1) * 100) / nbPages.value) * 5) / 100) + 3)
@@ -305,7 +305,7 @@ export default defineComponent({
                             arr[processedKey] = [];
                         }
                         arr[processedKey].push(String(item[key]));
-                    }  
+                    }
                 }
             });
 

--- a/src/components/datagouv/ImporterForm.vue
+++ b/src/components/datagouv/ImporterForm.vue
@@ -20,7 +20,7 @@
 
     <div v-if="currentStep === 'selectOrganization'">
     <!-- 2/ cette page est celle qui est affichée quand on propose à l'utilisateur de choisir dans quelle organisation dgv rechercher la donnée.
-     Si l'utilisateur n'a pas d'organisation sur dgv, on ne lui montre que le bouton de recherche globale. -->
+     Si l'utilisateur n'a pas d'organisation, cette étape est sautée. -->
         <div v-if="profile && profile.organizations && profile.organizations.length > 0">
             <p>À quelle organisation appartient le jeu de données que vous souhaitez importer dans Grist ?</p>
             <div v-for="item in profile.organizations" v-bind:key="item.id">

--- a/src/components/datagouv/ImporterForm.vue
+++ b/src/components/datagouv/ImporterForm.vue
@@ -20,7 +20,7 @@
 
     <div v-if="showChoices && selectedTable != ''">
     <!-- 2/ cette page est celle qui est affichée quand on propose à l'utilisateur de choisir dans quelle organisation dgv rechercher la donnée.
-     Si l'utilisateur n'a pas d'organisation sur dgv, on peut sauter cette étape. -->
+     Si l'utilisateur n'a pas d'organisation sur dgv, on ne lui montre que le bouton de recherche globale. -->
         <div v-if="profile && profile.organizations && profile.organizations.length > 0">
             <p>A quel organisation appartient le jeu de données que vous souhaitez importer dans Grist ?</p>
             <div v-for="item in profile.organizations" v-bind:key="item.id">
@@ -40,15 +40,15 @@
                 </div>
                 <br />
             </div>
-            <div @click="selectOrganization(null, null)" class="fr-tile fr-tile--sm fr-tile--horizontal fr-enlarge-link" id="tile-6661">
+        </div>
+        <div @click="selectOrganization(null, null)" class="fr-tile fr-tile--sm fr-tile--horizontal fr-enlarge-link" id="tile-6661">
                 <div class="fr-tile__body">
                     <div class="fr-tile__content">
                         <h3 class="fr-tile__title">
-                            <a href="#">Récupérer des données qui ne sont pas dans mes organisations</a>
+                            <a href="#">Récupérer des données sur tout data.gouv.fr</a>
                         </h3>
                     </div>
                 </div>
-            </div>
         </div>
     </div>
 

--- a/src/components/datagouv/ImporterForm.vue
+++ b/src/components/datagouv/ImporterForm.vue
@@ -123,7 +123,7 @@ export default defineComponent({
     const store = useStore();
     const showInputSearch = ref(true)
     const logoSelectedOrg = ref("")
-    const showChoices = ref(true)
+    const showDatasetSelector = ref(false)
     const searchText = ref("")
     const resources = ref<Resource[]>([]);
     const selectedTable = ref("")
@@ -159,7 +159,7 @@ export default defineComponent({
     }
 
     const selectOrganization = async (org: string|null, logo: string) => {
-        showChoices.value = false;
+        showDatasetSelector.value = true;
         if (org){
             logoSelectedOrg.value = logo
             showInputSearch.value = false;
@@ -333,9 +333,10 @@ export default defineComponent({
     const profile = computed(() => store.state.profile);
 
     const currentStep = computed(() => {
-      if (showLoader.value) return "loading";
+      // In reverted order so that later steps have precedence
       if (isImported.value) return "imported";
-      if (!showChoices.value) return "searchDataset";
+      if (showLoader.value) return "loading";
+      if (showDatasetSelector.value) return "searchDataset";
       if (selectedTable.value !== "") {
         const hasOrganizations = profile.value?.organizations?.length > 0;
         return hasOrganizations ? "selectOrganization" : "searchDataset";
@@ -350,7 +351,7 @@ export default defineComponent({
         selectOrganization,
         showInputSearch,
         logoSelectedOrg,
-        showChoices,
+        showDatasetSelector,
         searchText,
         searchDatagouv: debouncedSearch,
         resources,

--- a/src/components/datagouv/ImporterForm.vue
+++ b/src/components/datagouv/ImporterForm.vue
@@ -22,7 +22,7 @@
     <!-- 2/ cette page est celle qui est affichée quand on propose à l'utilisateur de choisir dans quelle organisation dgv rechercher la donnée.
      Si l'utilisateur n'a pas d'organisation sur dgv, on ne lui montre que le bouton de recherche globale. -->
         <div v-if="profile && profile.organizations && profile.organizations.length > 0">
-            <p>A quel organisation appartient le jeu de données que vous souhaitez importer dans Grist ?</p>
+            <p>À quelle organisation appartient le jeu de données que vous souhaitez importer dans Grist ?</p>
             <div v-for="item in profile.organizations" v-bind:key="item.id">
                 <div @click="selectOrganization(item.id, item.logo_thumbnail)" class="fr-tile fr-tile--sm fr-tile--horizontal fr-enlarge-link" id="tile-6661">
                     <div class="fr-tile__body">

--- a/src/components/datagouv/ImporterForm.vue
+++ b/src/components/datagouv/ImporterForm.vue
@@ -1,22 +1,25 @@
 <template>
-    <div>
-    <!-- cette page est celle qui est affichée quand l'import est en cours -->
-        <div v-if="showLoader" class="fr-stepper">
-            <h2 class="fr-stepper__title">
-                En cours d'importation dans la table {{ selectedTable }}
-            </h2>
-            <div class="fr-stepper__steps" :data-fr-current-step="ongoingStep" data-fr-steps="8"></div>
+
+    <div v-if="showChoices && selectedTable == ''">
+    <!-- 1/ cette page est celle qui est affichée pour choisir quelle table Grist utiliser -->
+        <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="radio-hint-legend">
+            Sélectionnez la table que vous voulez utiliser.
+            <span class="fr-hint-text">Attention, toute donnée de cette table sera supprimée</span>
+        </legend>
+        <div v-for="item in activeGristTables" v-bind:key="item">
+            <div class="fr-fieldset__element">
+                <div class="fr-radio-group">
+                    <input type="radio" :id="item" :name="item" :value="item" v-model="selectedTable">
+                    <label class="fr-label" :for="item">
+                        {{ item }}
+                    </label>
+                </div>
+            </div>
         </div>
     </div>
 
-    <div v-if="!showLoader && isImported">
-    <!-- cette page est celle qui est affichée quand l'import est terminé -->
-        <br />
-        🎉 Données importées dans la table {{ selectedTable }}
-    </div>
-
     <div v-if="showChoices && selectedTable != ''">
-    <!-- cette page est celle qui est affichée quand on propose à l'utilisateur de choisir dans quelle organisation dgv rechercher la donnée.
+    <!-- 2/ cette page est celle qui est affichée quand on propose à l'utilisateur de choisir dans quelle organisation dgv rechercher la donnée.
      Si l'utilisateur n'a pas d'organisation sur dgv, on peut sauter cette étape. -->
         <div v-if="profile && profile.organizations && profile.organizations.length > 0">
             <p>A quel organisation appartient le jeu de données que vous souhaitez importer dans Grist ?</p>
@@ -49,27 +52,8 @@
         </div>
     </div>
 
-
-    <div v-if="showChoices && selectedTable == ''">
-    <!-- cette page est celle qui est affichée pour choisir quelle table Grist utiliser -->
-        <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="radio-hint-legend">
-            Sélectionnez la table que vous voulez utiliser.
-            <span class="fr-hint-text">Attention, toute donnée de cette table sera supprimée</span>
-        </legend>
-        <div v-for="item in activeGristTables" v-bind:key="item">
-            <div class="fr-fieldset__element">
-                <div class="fr-radio-group">
-                    <input type="radio" :id="item" :name="item" :value="item" v-model="selectedTable">
-                    <label class="fr-label" :for="item">
-                        {{ item }}
-                    </label>
-                </div>
-            </div>
-        </div>
-    </div>
-
     <div v-if="!showChoices && selectedTable != '' && !isImported && !showLoader">
-    <!-- cette page est celle qui est affichée pour rechercher un jeu de données -->
+    <!-- 3/ cette page est celle qui est affichée pour rechercher un jeu de données -->
         <div v-if="showInputSearch">
             <label class="fr-label" for="text-input-text">Rechercher un jeu de données</label>
             <input class="fr-input" type="text" id="text-input-text" name="text-input-text" v-model="searchText" @input="searchDatagouv()">
@@ -88,6 +72,22 @@
             </div>
             <br />
         </div>
+    </div>
+
+    <div>
+    <!-- 4/ cette page est celle qui est affichée quand l'import est en cours -->
+        <div v-if="showLoader" class="fr-stepper">
+            <h2 class="fr-stepper__title">
+                En cours d'importation dans la table {{ selectedTable }}
+            </h2>
+            <div class="fr-stepper__steps" :data-fr-current-step="ongoingStep" data-fr-steps="8"></div>
+        </div>
+    </div>
+
+    <div v-if="!showLoader && isImported">
+    <!-- 5/ cette page est celle qui est affichée quand l'import est terminé -->
+        <br />
+        🎉 Données importées dans la table {{ selectedTable }}
     </div>
 
 

--- a/src/components/datagouv/ImporterForm.vue
+++ b/src/components/datagouv/ImporterForm.vue
@@ -1,5 +1,6 @@
 <template>
     <div>
+    <!-- cette page est celle qui est affichée quand l'import est en cours -->
         <div v-if="showLoader" class="fr-stepper">
             <h2 class="fr-stepper__title">
                 En cours d'importation dans la table {{ selectedTable }}
@@ -9,11 +10,14 @@
     </div>
 
     <div v-if="!showLoader && isImported">
+    <!-- cette page est celle qui est affichée quand l'import est terminé -->
         <br />
         🎉 Données importées dans la table {{ selectedTable }}
     </div>
 
     <div v-if="showChoices && selectedTable != ''">
+    <!-- cette page est celle qui est affichée quand on propose à l'utilisateur de choisir dans quelle organisation dgv rechercher la donnée.
+     Si l'utilisateur n'a pas d'organisation sur dgv, on peut sauter cette étape. -->
         <div v-if="profile && profile.organizations && profile.organizations.length > 0">
             <p>A quel organisation appartient le jeu de données que vous souhaitez importer dans Grist ?</p>
             <div v-for="item in profile.organizations" v-bind:key="item.id">
@@ -47,6 +51,7 @@
 
 
     <div v-if="showChoices && selectedTable == ''">
+    <!-- cette page est celle qui est affichée pour choisir quelle table Grist utiliser -->
         <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="radio-hint-legend">
             Sélectionnez la table que vous voulez utiliser.
             <span class="fr-hint-text">Attention, toute donnée de cette table sera supprimée</span>
@@ -64,6 +69,7 @@
     </div>
 
     <div v-if="!showChoices && selectedTable != '' && !isImported && !showLoader">
+    <!-- cette page est celle qui est affichée pour rechercher un jeu de données -->
         <div v-if="showInputSearch">
             <label class="fr-label" for="text-input-text">Rechercher un jeu de données</label>
             <input class="fr-input" type="text" id="text-input-text" name="text-input-text" v-model="searchText" @input="searchDatagouv()">


### PR DESCRIPTION
Fixes #7

This is a quick fix that lets users without an org select the "Récupérer des données sur tout data.gouv.fr" option in the second screen. Its not optimal : in an ideal world we would skip this step altogether for those users but I've invested a bit too much time into this already.

The commit that fixes the issue is f6ed3a0dd855e3793fa9219d09c321657087ece6, the other two are documenting the code and reorganizing it, feel free to ignore !