### PR TITLE
Feat/oauth and streaming publication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@gouvminint/vue-dsfr": "^5.17.2",
         "core-js": "^3.8.3",
         "grist-api": "^0.1.7",
+        "papaparse": "^5.5.2",
         "vue": "^3.2.13",
         "vue-class-component": "^8.0.0-0",
         "vue-router": "^4.0.13",
@@ -21,6 +22,7 @@
       "devDependencies": {
         "@babel/core": "^7.12.16",
         "@babel/eslint-parser": "^7.12.16",
+        "@types/papaparse": "^5.3.15",
         "@typescript-eslint/eslint-plugin": "^5.4.0",
         "@typescript-eslint/parser": "^5.4.0",
         "@vue/cli-plugin-babel": "~5.0.0",
@@ -2417,6 +2419,15 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
+    },
+    "node_modules/@types/papaparse": {
+      "version": "5.3.15",
+      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.3.15.tgz",
+      "integrity": "sha512-JHe6vF6x/8Z85nCX4yFdDslN11d+1pr12E526X8WAfhadOeaOTx5AuIkvDKIBopfvlzpzkdMx4YyvSKCM9oqtw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
@@ -10014,6 +10025,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/papaparse": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.2.tgz",
+      "integrity": "sha512-PZXg8UuAc4PcVwLosEEDYjPyfWnTEhOrUfdv+3Bx+NuAb+5NhDmXzg5fHWmdCh1mP5p7JAZfFr3IMQfcntNAdA=="
+    },
     "node_modules/param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -15345,6 +15361,15 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
+    },
+    "@types/papaparse": {
+      "version": "5.3.15",
+      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.3.15.tgz",
+      "integrity": "sha512-JHe6vF6x/8Z85nCX4yFdDslN11d+1pr12E526X8WAfhadOeaOTx5AuIkvDKIBopfvlzpzkdMx4YyvSKCM9oqtw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/parse-json": {
       "version": "4.0.2",
@@ -20933,6 +20958,11 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
+    },
+    "papaparse": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.2.tgz",
+      "integrity": "sha512-PZXg8UuAc4PcVwLosEEDYjPyfWnTEhOrUfdv+3Bx+NuAb+5NhDmXzg5fHWmdCh1mP5p7JAZfFr3IMQfcntNAdA=="
     },
     "param-case": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@gouvminint/vue-dsfr": "^5.17.2",
     "core-js": "^3.8.3",
     "grist-api": "^0.1.7",
+    "papaparse": "^5.5.2",
     "vue": "^3.2.13",
     "vue-class-component": "^8.0.0-0",
     "vue-router": "^4.0.13",
@@ -21,6 +22,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.16",
     "@babel/eslint-parser": "^7.12.16",
+    "@types/papaparse": "^5.3.15",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
     "@vue/cli-plugin-babel": "~5.0.0",

--- a/public/oauth-callback.html
+++ b/public/oauth-callback.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>OAuth callback</title>
+<script>
+  const p = new URLSearchParams(location.search);
+  const code  = p.get('code');
+  const state = p.get('state');
+  if (window.opener && code) {
+    window.opener.postMessage({ code, state }, location.origin);
+    try { window.close(); } catch (_) {}
+  }
+  document.body.textContent =
+    code ? 'Connexion réussie, vous pouvez revenir à l’application…'
+         : 'Erreur OAuth';
+</script>

--- a/src/components/HeaderWidget.vue
+++ b/src/components/HeaderWidget.vue
@@ -32,31 +32,6 @@
     <div class="item-subpart">
       <span> Open data widget (version bêta) </span>
     </div>
-
-    <!-- Navigation Menu -->
-    <nav
-      class="fr-nav"
-      id="header-navigation"
-      role="navigation"
-      aria-label="Menu principal"
-    >
-      <ul class="fr-nav__list">
-        <li class="fr-nav__item">
-          <router-link class="fr-nav__link" to="/" aria-label="Widget DataGouv">
-            DataGouv
-          </router-link>
-        </li>
-        <li class="fr-nav__item">
-          <router-link
-            class="fr-nav__link"
-            to="/validata"
-            aria-label="Widget Validata"
-          >
-            Validata
-          </router-link>
-        </li>
-      </ul>
-    </nav>
   </div>
 </template>
 

--- a/src/components/datagouv/AuthentificationConnection.vue
+++ b/src/components/datagouv/AuthentificationConnection.vue
@@ -1,0 +1,64 @@
+<template>
+    <br />
+  
+    <div v-if="!profile.first_name">
+      <p class="fr-mb-2w">Vous n’êtes pas connecté·e à data.gouv.fr</p>
+      <button class="fr-btn" @click="login">Se connecter avec data.gouv.fr</button>
+    </div>
+  </template>
+  
+  <script lang="ts">
+  import { defineComponent, ref, computed, onMounted, onUnmounted } from 'vue';
+  import { useStore } from 'vuex';
+  import AuthService from '@/services/AuthService';
+  
+  const auth = new AuthService();
+  const BASE_URL = process.env.VUE_APP_DATAGOUV_PUBLISH_URL ?? 'https://www.data.gouv.fr';
+  
+  export default defineComponent({
+    name: 'AuthenticationConnection',
+    setup () {
+      const store = useStore();
+      const authTab = ref<Window | null>(null);
+  
+      async function login () {
+        const url = await auth.getRedirectURL();
+        authTab.value = window.open(url, '_blank');
+        if (!authTab.value) alert('Popup bloquée : autorisez‑la.');
+      }
+
+      async function handleMessage (e: MessageEvent) {
+        if (e.origin !== new URL(auth.redirectURI).origin) return;
+        const { code, state } = e.data || {};
+        if (!code || !state) return;
+        authTab.value = null;
+  
+        let token: string;
+        try {
+          token = await auth.retrieveToken(code as string, state as string);
+        } catch (err) {
+          alert('Erreur OAuth : ' + (err as Error).message);
+          auth.cleanup();
+          return;
+        }
+  
+        const me = await fetch(`${BASE_URL}/api/1/me/`, {
+          headers: { Authorization: `Bearer ${token}` }
+        }).then(r => r.json());
+  
+        store.dispatch('updateToken',   token);
+        store.dispatch('updateProfile', me);
+        auth.cleanup();
+      }
+  
+      onMounted(() => window.addEventListener('message', handleMessage));
+      onUnmounted(() => window.removeEventListener('message', handleMessage));
+  
+      return {
+        login,
+        profile: computed(() => store.state.profile)
+      };
+    }
+  });
+  </script>
+  

--- a/src/components/datagouv/GristWidget.vue
+++ b/src/components/datagouv/GristWidget.vue
@@ -1,16 +1,10 @@
 <template>
   <header-widget />
-
-  <div v-if="!profile.first_name">
-    <token-form />
-  </div>
-
-  <div v-else>
+  <div>
     <span v-if="menuOption">
       <span class="ariane" @click="resetMenu()">Retour à l'accueil</span>
     </span>
     <span v-if="!menuOption">
-      Bonjour <b>{{ profile.first_name }} {{ profile.last_name }}</b>, dites-nous ce qui vous amène.
       <menu-widget />
     </span>
     <div v-if="menuOption === 'publier'">
@@ -22,32 +16,26 @@
     <div v-if="menuOption === 'importer'">
       <importer-form />
     </div>
+    <div v-if="menuOption === 'validata'">
+      <validata-widget />
+    </div>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, onMounted } from 'vue';
+import { defineComponent, computed } from 'vue';
 import HeaderWidget from '../HeaderWidget.vue';
-import TokenForm from './TokenForm.vue';
 import MenuWidget from './MenuWidget.vue';
 import PublierForm from './PublierForm.vue';
 import SchemaForm from './SchemaForm.vue';
 import ImporterForm from './ImporterForm.vue';
 import { useStore } from 'vuex';
+import ValidataWidget from '../validata/ValidataWidget.vue';
 
 export default defineComponent({
   name: 'GristWidget',
-  components: { HeaderWidget, TokenForm, MenuWidget, PublierForm, SchemaForm, ImporterForm },
+  components: { HeaderWidget, MenuWidget, PublierForm, SchemaForm, ImporterForm, ValidataWidget },
   setup() {
-
-    onMounted(async () => {
-        const token = await window.grist.getOption('token_datagouv');
-        const profile = await window.grist.getOption('profile_datagouv');
-        if (token && profile) {
-          store.dispatch('updateToken', token);
-          store.dispatch('updateProfile', profile);
-        }
-    });
 
     const store = useStore();
     window.grist.ready({

--- a/src/components/datagouv/MenuWidget.vue
+++ b/src/components/datagouv/MenuWidget.vue
@@ -60,6 +60,22 @@
         </div>
     </div>
     <br />
+    <div @click="setMenuOptions('validata')" class="fr-tile fr-tile--sm fr-tile--horizontal fr-enlarge-link" id="tile-6661">
+        <div class="fr-tile__body">
+            <div class="fr-tile__content">
+                <h3 class="fr-tile__title">
+                    <a href="#">Je veux valider mes données à partir d'un schéma de données</a>
+                </h3>
+                <p class="fr-tile__detail">Utiliser l'outil Validata pour valider le contenu et la structure de ses données par rapport à un schéma de donnée existant, référencé ou non sur schema.data.gouv.fr</p>
+            </div>
+        </div>
+        <div class="fr-tile__header">
+            <div class="fr-tile__pictogram">
+              <svg fill="#060091" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><path d="M72.7,65.8a6.6,6.6,0,0,0-3.2.8l-8.8-6.5a11.36,11.36,0,0,0,1.2-5.2A11.91,11.91,0,0,0,53,43.4v-10a7,7,0,0,0,4-6.2,6.9,6.9,0,1,0-13.8,0,6.73,6.73,0,0,0,4,6.2v10a11.91,11.91,0,0,0-8.9,11.5,11.36,11.36,0,0,0,1.2,5.2l-8.8,6.5a7.22,7.22,0,0,0-3.2-.8,6.9,6.9,0,1,0,6.9,6.9c0-.5-.1-.9-.1-1.3l9.2-6.8a11.61,11.61,0,0,0,13.6,0l9.2,6.8a5.7,5.7,0,0,0-.1,1.3,6.9,6.9,0,0,0,13.8,0A7.41,7.41,0,0,0,72.7,65.8ZM51.4,60.7a6.75,6.75,0,0,1-1.4.2,6.1,6.1,0,0,1-5.7-4.4,7.72,7.72,0,0,1-.2-1.5,5.81,5.81,0,0,1,3-5.1,6,6,0,0,1,6,0,5.81,5.81,0,0,1,3,5.1,7.72,7.72,0,0,1-.2,1.5A6.54,6.54,0,0,1,51.4,60.7Z"/></svg>
+            </div>
+        </div>
+    </div>
+    <br />
 </template>
 
 

--- a/src/components/datagouv/TokenForm.vue
+++ b/src/components/datagouv/TokenForm.vue
@@ -20,7 +20,7 @@ export default defineComponent({
     const store = useStore();
     const token = ref('');
     const isTokenSet = ref(false);
-    const datagouvUrl = process.env.VUE_APP_DATAGOUV_PUBLISH_URL;
+    const datagouvUrl = process.env.VUE_APP_DATAGOUV_PUBLISH_URL ?? "";
     const urlDisplay = ref("")
 
     onMounted(() => {

--- a/src/components/datagouv/catalogue/AccueilCatalogue.vue
+++ b/src/components/datagouv/catalogue/AccueilCatalogue.vue
@@ -82,8 +82,8 @@ export default defineComponent({
   name: 'AccueilCatalogue',
   components: { HeaderWidget },
   setup() {
-    const gristUrl = process.env.VUE_APP_GRIST_URL
-    const datagouvUrl = process.env.VUE_APP_DATAGOUV_IMPORT_URL
+    const gristUrl = process.env.VUE_APP_GRIST_URL ?? ""
+    const datagouvUrl = process.env.VUE_APP_DATAGOUV_IMPORT_URL ?? ""
     const docId: any = ref(null)
     const dataGouvOrganization = ref("")
     const dataGouvOrganizationId = ref("")
@@ -156,7 +156,6 @@ export default defineComponent({
         }
 
         // 1 - Regarder si l'orga est présente dans la table orga. Si non, l'ajouter et ajouter son siret
-
         let url = datagouvUrl + "/api/1/organizations/" + dataGouvOrganizationId.value
         let data = await queryUrl(url)
         let orgaName = data.name
@@ -192,12 +191,12 @@ export default defineComponent({
         }
 
         // 2 - Récupérer les tables frequency, couverture geo et licence et format
-
-        const frequencies = await utilsGetMetadata(gristUrl, docId.value, "Ref_Frequency", tokenInfo.value.token)
-        const geocoverages = await utilsGetMetadata(gristUrl, docId.value, "Ref_GeographicalCoverage", tokenInfo.value.token)
-        const licences = await utilsGetMetadata(gristUrl, docId.value, "Ref_Licence", tokenInfo.value.token)
+        const token = tokenInfo.value.token!;
+        const frequencies = await utilsGetMetadata(gristUrl, docId.value, "Ref_Frequency", token)
+        const geocoverages = await utilsGetMetadata(gristUrl, docId.value, "Ref_GeographicalCoverage", token)
+        const licences = await utilsGetMetadata(gristUrl, docId.value, "Ref_Licence", token)
         //specific process for formats
-        url = gristUrl + "/api/docs/" + docId.value + "/tables/Ref_Format/records?auth=" + tokenInfo.value.token
+        url = gristUrl + "/api/docs/" + docId.value + "/tables/Ref_Format/records?auth=" + token
         data = await queryUrl(url)
         const formats: any = {};
         data.records.forEach((item: { fields: { valeur: string|number; }; id: any; }) => {

--- a/src/components/validata/ValidataWidget.vue
+++ b/src/components/validata/ValidataWidget.vue
@@ -1,5 +1,4 @@
 <template>
-  <header-widget />
   <!DOCTYPE html>
   <html lang="fr">
     <head>
@@ -32,7 +31,6 @@
 
 <script lang="ts">
 import { defineComponent, ref } from "vue";
-import HeaderWidget from "../HeaderWidget.vue";
 
 import { errors } from "./plugin";
 import ValidationReport from "./ValidationReport.vue";
@@ -57,7 +55,7 @@ const COUNTDOWN_SECONDS = 1;
 
 export default defineComponent({
   name: "ValidataWidget",
-  components: { ValidationReport, SchemaPicker, HeaderWidget },
+  components: { ValidationReport, SchemaPicker },
   setup() {
     async function handleSubmit(event: SubmitEvent) {
       const schemaURL = _get_schema_url(event);

--- a/src/components/validata/infra/validata.ts
+++ b/src/components/validata/infra/validata.ts
@@ -5,7 +5,7 @@ interface Options {
   header_case?: boolean;
 }
 
-const VALIDATA_URL = process.env.VUE_APP_VALIDATA_URL;
+const VALIDATA_URL = process.env.VUE_APP_VALIDATA_URL ?? "";
 if (!VALIDATA_URL) {
   throw new Error("Please define VUE_APP_VALIDATA_URL environment variable");
 }

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -1,0 +1,71 @@
+import OauthAPI from '@/services/OauthAPI';
+
+const BASE_URL  = process.env.VUE_APP_DATAGOUV_PUBLISH_URL  ?? 'https://www.data.gouv.fr';
+const CLIENT_ID = process.env.VUE_APP_DATAGOUV_CLIENT_ID ?? '';
+
+const api = new OauthAPI();
+
+export default class AuthService {
+  clientId    = CLIENT_ID;
+  baseURL     = BASE_URL;
+  redirectURI = `${window.location.origin}/oauth-callback.html`;
+
+  async getRedirectURL (): Promise<string> {
+    const verifier  = this.randomString();
+    const challenge = await this.pkceChallenge(verifier);
+    const state     = this.randomString();
+
+    localStorage.setItem('pkceCodeVerifier', verifier);
+    localStorage.setItem('pkceState',        state);
+
+    const p = new URLSearchParams({
+      redirect_uri:            this.redirectURI,
+      response_type:           'code',
+      state,
+      client_id:               this.clientId,
+      scope:                   'default',
+      code_challenge:          challenge,
+      code_challenge_method:   'S256'
+    });
+
+    return `${this.baseURL}/oauth/authorize?${p.toString()}`;
+  }
+
+  async retrieveToken (code: string, state: string): Promise<string> {
+    if (state !== localStorage.getItem('pkceState'))
+      throw new Error('state mismatch');
+
+    const verifier = localStorage.getItem('pkceCodeVerifier')!;
+    return api.token({
+      code,
+      pkceCodeVerifier: verifier,
+      clientId:   this.clientId,
+      redirectURI: this.redirectURI
+    });
+  }
+
+  logout (token: string) {
+    return api.logout(token, this.clientId);
+  }
+
+  cleanup () {
+    localStorage.removeItem('pkceCodeVerifier');
+    localStorage.removeItem('pkceState');
+  }
+
+  private randomString (len = 32): string {
+    const a = crypto.getRandomValues(new Uint8Array(len));
+    return Array.from(a, b => b.toString(16).padStart(2, '0')).join('');
+  }
+  private async sha256 (v: string) {
+    return crypto.subtle.digest('SHA-256', new TextEncoder().encode(v));
+  }
+  private base64url (buf: ArrayBuffer) {
+    return btoa(String.fromCharCode(...new Uint8Array(buf)))
+      .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  }
+  private async pkceChallenge (v: string) {
+    const hash = await this.sha256(v);
+    return this.base64url(hash);
+  }
+}

--- a/src/services/OauthAPI.ts
+++ b/src/services/OauthAPI.ts
@@ -1,0 +1,37 @@
+import type { AxiosResponse } from 'axios';
+import axios from 'axios';
+
+const BASE_URL = process.env.VUE_APP_DATAGOUV_PUBLISH_URL ?? 'https://www.data.gouv.fr';
+
+interface TokenParams {
+  code: string;
+  pkceCodeVerifier: string;
+  clientId: string;
+  redirectURI: string;
+}
+
+export default class OauthAPI {
+  async token (p: TokenParams): Promise<string> {
+    const url = `${BASE_URL}/oauth/token`;
+
+    const form = new FormData();
+    form.append('grant_type',    'authorization_code');
+    form.append('code',          p.code);
+    form.append('redirect_uri',  p.redirectURI);
+    form.append('client_id',     p.clientId);
+    form.append('code_verifier', p.pkceCodeVerifier);
+
+    const { data } = await axios.post(url, form);
+    return data.access_token;
+  }
+
+  async logout (token: string, clientId: string): Promise<AxiosResponse> {
+    const url = `${BASE_URL}/oauth/revoke`;
+
+    const form = new FormData();
+    form.append('token',      token);
+    form.append('client_id',  clientId);
+
+    return axios.post(url, form);
+  }
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,84 +1,80 @@
 import { createStore } from 'vuex';
-
 interface State {
-  docId: String;
-  tableId: String;
-  token: String;
-  profile: Object;
-  menuOption: String|null;
-  publierOrganization: String|null;
-  publierTables: Array<String>;
-  activeGristTables: Array<String>;
+  docId: string;
+  tableId: string;
+  token: string;
+  apikey: string;
+  profile: Record<string, any>;
+  menuOption: string | null;
+  publierOrganization: string | null;
+  publierTables: string[];
+  activeGristTables: string[];
+}
+
+function loadPersisted<T = string>(key: string, fallback: T): T {
+  try {
+    const v = localStorage.getItem(key);
+    return v ? (v as unknown as T) : fallback;
+  } catch { return fallback; }
 }
 
 const store = createStore<State>({
   state: {
-    docId: "",
-    tableId: "",
-    token: "",
-    profile: {},
-    menuOption: null,
+    docId:              '',
+    tableId:            '',
+    token:              loadPersisted('dg_token', ''),
+    apikey:             loadPersisted('dg_apikey', ''),
+    profile:            {},
+    menuOption:         null,
     publierOrganization: null,
-    activeGristTables: [],
-    publierTables: [],
+    publierTables:      [],
+    activeGristTables:  []
   },
   mutations: {
-    setTableId(state, payload: String) {
-      state.tableId = payload
-    },
-    setDocId(state, payload: String) {
-      state.docId = payload
-    },
-    setToken(state, payload: String) {
-      state.token = payload
-    },
-    setProfile(state, payload: String) {
-      state.profile = payload
-    },
-    setMenuOption(state, payload: String) {
-      state.menuOption = payload
-    },
-    setPublierOrganization(state, payload: String) {
-      state.publierOrganization = payload
-    },
-    setActiveGristTables(state, payload: Array<String>) {
-      state.activeGristTables = payload
-    },
-    setPublierTables(state, payload: Array<String>) {
-      state.publierTables = payload
-    }
+    setTableId          (s, v: string) { s.tableId = v; },
+    setDocId            (s, v: string) { s.docId = v; },
+    setToken            (s, v: string) { s.token = v; },
+    setApiKey           (s, v: string) { s.apikey = v; },
+    setProfile          (s, v: Record<string, any>) { s.profile = v; },
+    setMenuOption       (s, v: string) { s.menuOption = v; },
+    setPublierOrganization (s, v: string|null) { s.publierOrganization = v; },
+    setActiveGristTables(s, v: string[]) { s.activeGristTables = v; },
+    setPublierTables    (s, v: string[]) { s.publierTables = v; },
+    clearAuth           (s) { s.token = s.apikey = ''; s.profile = {}; }
   },
   actions: {
-    updateDocId({ commit }, id) {
-      commit('setDocId', id);
-    },
-    updateToken({ commit }, token) {
+    updateDocId({ commit }, id)      { commit('setDocId', id); },
+    updateToken({ commit }, token)   {
       commit('setToken', token);
+      localStorage.setItem('dg_token', token);
     },
-    updateProfile({ commit }, profile) {
+    updateProfile({ commit, dispatch }, profile) {
       commit('setProfile', profile);
+      if (profile?.apikey) dispatch('updateApiKey', profile.apikey);
     },
-    updateMenuOption({ commit }, menuOption) {
-      commit('setMenuOption', menuOption);
+    logout({ commit }) {
+      commit('clearAuth');
+      localStorage.removeItem('dg_token');
+      localStorage.removeItem('dg_apikey');
     },
-    updatePublierOrganization({ commit }, publierOrganization) {
-      commit('setPublierOrganization', publierOrganization);
-    },
-    updateActiveGristTables({ commit }, activeGristTables) {
-      commit('setActiveGristTables', activeGristTables);
-    },
-    updatePublierTables({ commit }, publierTables) {
-      commit('setPublierTables', publierTables);
-    }
+    /* actions déjà présentes */
+    updateMenuOption        ({ commit }, v) { commit('setMenuOption', v); },
+    updatePublierOrganization({ commit }, v){ commit('setPublierOrganization', v); },
+    updateActiveGristTables ({ commit }, v) { commit('setActiveGristTables', v); },
+    updatePublierTables     ({ commit }, v) { commit('setPublierTables', v); }
   },
   getters: {
-    docId: state => state.docId,
-    token: state => state.token,
-    profile: state => state.profile,
-    menuOption: state => state.menuOption,
-    publierOrganization: state => state.publierOrganization,
-    activeGristTables: state => state.activeGristTables,
-    publierTables: state => state.publierTables,
+    /* existants */
+    docId:      s => s.docId,
+    token:      s => s.token,
+    apikey:     s => s.apikey,
+    bearer:     s => (s.token ? `Bearer ${s.token}` : ''),
+    profile:    s => s.profile,
+    isLogged:   s => !!s.token,
+    menuOption: s => s.menuOption,
+    publierOrganization: s => s.publierOrganization,
+    activeGristTables:   s => s.activeGristTables,
+    publierTables:       s => s.publierTables
   }
 });
 


### PR DESCRIPTION
[x] Arrêt du sous-menu "Validata" et "DataGouv" : tout les CTA sont regroupés sur la homepage via des cartes cliquables
[x] Fil d'ariane enlevé car plus nécessaire (il reste seulement le bouton "Retour à l'accueil)
[x] Ajout de l'OAuth pour l'authentification sur le plugin plutôt que copie du token
[x] Ajout de la possibilité de charger à la volée les données plutôt que de les référencer si le document grist n'est pas en accès public
[x] Ajout d'un champ "titre de la ressource" pour le formulaire de publication