### PR TITLE
Change le wording de la publication

### DIFF
--- a/src/components/datagouv/PublierForm.vue
+++ b/src/components/datagouv/PublierForm.vue
@@ -58,12 +58,12 @@
     
       <div v-if="isSelectedTable">
         <button class="fr-btn btn-publish" @click="validateTable('remote')">
-          Publier la table en faisant une référence à ce fichier grist sur data.gouv.fr
+          Publier sur data.gouv.fr en faisant référence à la table Grist
         </button>
-        <div class="petite-ligne"><b>pré-requis :</b> rendre votre document grist en accès public</div>
+        <div class="petite-ligne"><b>pré-requis :</b> rendre votre document Grist en accès public</div>
         <br />
-        <button class="fr-btn fr-btn--secondary btn-publish" @click="validateTable('file')">Publier la table en uploadant le fichier sur data.gouv.fr</button>
-        <div class="petite-ligne"><b>Attention : </b>Les modifications effectuées sur ce grist ne seront visibles que si vous mettez à jour manuellement la table via ce plugin</div>
+        <button class="fr-btn fr-btn--secondary btn-publish" @click="validateTable('file')">Publier sur data.gouv.fr en téléchargeant la table Grist</button>
+        <div class="petite-ligne"><b>Attention : </b>Les modifications effectuées sur cette table Grist ne seront visibles sur data.gouv.fr que si vous faites une mise à jour manuelle via ce plugin</div>
       </div>
     </div>
 


### PR DESCRIPTION
Actuellement : 

![image](https://github.com/user-attachments/assets/3dee1616-c53e-43af-91d5-c351157b92ac)

Proposition :

Publier sur data.gouv.fr en faisant référence à la table Grist  
**pré-requis :** rendre votre document Grist en accès public

Publier sur data.gouv.fr en téléchargeant la table Grist  
**Attention :** Les modifications effectuées sur cette table Grist ne seront visibles sur data.gouv.fr que si vous faites une mise à jour manuelle via ce plugin